### PR TITLE
Fixed rpmbuild --target: in case of a version bigger than 4, it used …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,9 +390,9 @@ if test "x$RPM" != x; then
 		AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--buildarch ")
 	else
 		if test $rpmversion -ge 40003; then
-			AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--target ")
-		else
 			AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--target=")
+		else
+			AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--target ")
 		fi
 	fi
 fi
@@ -400,7 +400,18 @@ fi
 if test "x$RPMBUILD" != x; then
 	AC_DEFINE_UNQUOTED(EPM_RPMBUILD, "$RPMBUILD")
 	AC_DEFINE(EPM_RPMTOPDIR)
-	AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--buildarch ")
+	# It would be nice if Red Hat could make up its mind...
+	rpmversion="`$RPMBUILD --version | awk '{print $3}' | awk -F. '{print $1 * 10000 + $2 * 100 + $3}'`"
+
+	if test $rpmversion -lt 30000; then
+		AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--buildarch ")
+	else
+		if test $rpmversion -ge 40003; then
+			AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--target=")
+		else
+			AC_DEFINE_UNQUOTED(EPM_RPMARCH, "--target ")
+		fi
+	fi
 else
 	if test "x$RPM" != x; then
 		AC_DEFINE_UNQUOTED(EPM_RPMBUILD, "$RPM")


### PR DESCRIPTION
…the old --build-arch argument

I have also changed the argument for rpm, as version 4.1.4.3  stated that the --target version should be with a '=' sign.
      --target=CPU-VENDOR-OS         Specify target platform
In the logic in configure.ac any version bigger than 4.03 would use the --target CPU-VENDOR-OS
