### PR TITLE
FreeBSD fixes for a build regression, introduced in 8475324e0836a9154…

### DIFF
--- a/bsd.c
+++ b/bsd.c
@@ -200,9 +200,9 @@ make_subpackage(const char *prodname,   /* I - Product short name */
         if (d->type == DEPEND_REQUIRES) {
 #ifdef __FreeBSD__
             if (AooMode) {
-                if (dist->relnumber) {
+                if (dist->vernumber) {
                     fprintf(fp, "@pkgdep %s-%s-%d-%s", d->product, dist->version,
-                            dist->relnumber, platname);
+                            dist->vernumber, platname);
                 } else {
                     fprintf(fp, "@pkgdep %s-%s-%s", d->product, dist->version, platname);
                 }

--- a/qprintf.c
+++ b/qprintf.c
@@ -22,6 +22,7 @@
  * Include necessary headers...
  */
 
+#include "epm.h"
 #include "epmstring.h"
 #include <ctype.h>
 #include <stdio.h>


### PR DESCRIPTION
…63984fdbd8e9a6f090a1593.

There is no "relnumber", use "vernumber" instead.
Include "epm.h" for AooMode in qprintf.c.

(This doesn't actually get epm working - the pkg-plist format changed a lot time ago, but at least it gets AOO to build, as epm is built even when using --with-package-format="installed".)