### PR TITLE
'test' target of Makefile now passes all tests.

### DIFF
--- a/epm.list.in
+++ b/epm.list.in
@@ -30,10 +30,10 @@ $srcdir=@srcdir@
 
 # Product information
 %product ESP Package Manager (EPM)
-%copyright 1999-2020 by Michael R Sweet, All Rights Reserved.
 %copyright 2020 by Jim Jagielski, All Rights Reserved.
+%copyright 1999-2020 by Michael R Sweet, All Rights Reserved.
 %vendor Michael R Sweet, Jim Jagielski
-%license ${srcdir}/COPYING
+%license ${srcdir}/LICENSE
 %readme ${srcdir}/README.md
 %description Universal software packaging tool for UNIX.
 %version @VERSION@ @VERNUMBER@
@@ -48,7 +48,7 @@ f 0555 root sys ${bindir}/mkepmlist mkepmlist
 %subpackage documentation
 %description Documentation
 f 0444 root sys ${docdir}/README $srcdir/README.md
-f 0444 root sys ${docdir}/COPYING $srcdir/COPYING
+f 0444 root sys ${docdir}/LICENSE $srcdir/LICENSE
 f 0444 root sys ${docdir}/epm-book.html $srcdir/doc/epm-book.html
 
 # Man pages


### PR DESCRIPTION
Updated license file name to LICENCE in epm.list.in
Swapped %copyright lines so latest is read first.  EPM ignores 2nd and
subsequent %copyright lines.